### PR TITLE
Fixed error message when failed to pull image from registry

### DIFF
--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -37,7 +37,7 @@ func (e *CheckEngine) ExecuteChecks() {
 				log.Info("downloading image")
 				err := GetContainerFromRegistry(e.Image)
 				if err != nil {
-					log.Error("unable to the container from the registry: ", err)
+					log.Error("unable to pull the container from the registry: ", err)
 					e.results.Errors = append(e.results.Errors, runtime.Result{Check: check, ElapsedTime: time.Since(checkStartTime)})
 					continue
 				}


### PR DESCRIPTION
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
time="2021-07-09T09:19:48Z" level=error msg="unable to the container from the registry: failed to pull remote container: exit status 125"
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
time="2021-07-09T09:19:48Z" level=error msg="unable to the container from the registry: failed to pull remote container: exit status 125"
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
time="2021-07-09T09:19:48Z" level=error msg="**unable to the container from the registry**: failed to pull remote container: exit status 125"
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
time="2021-07-09T09:19:48Z" level=error msg="**unable to the container from the registry:** failed to pull remote container: exit status 125"
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
time="2021-07-09T09:19:48Z" level=error msg="unable to the container from the registry: failed to pull remote container: exit status 125"
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
time="2021-07-09T09:19:48Z" level=error msg="unable to the container from the registry: failed to pull remote container: exit status 125"
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
time="2021-07-09T09:19:48Z" level=error msg="unable to the container from the registry: failed to pull remote container: exit status 125"
time="2021-07-09T09:19:48Z" level=info msg="downloading image"
